### PR TITLE
Add config for pull_after_integrate

### DIFF
--- a/src/tool/configuration.md
+++ b/src/tool/configuration.md
@@ -19,6 +19,7 @@ verify_isolation = true
 [integrate]
 verify_isolation = true
 prompt_for_reassurance = true
+pull_after_integrate = false
 ```
 
 The following is a breakdown of the supported settings.
@@ -27,4 +28,5 @@ The following is a breakdown of the supported settings.
 - `request_review.verify_isolation` - (**true**/**false** default: **true**) - if **yes** the `request-review` command will run the `isolate` command & it's hooks to verify the patch is isolated prior to requesting review. If the isolation verification fails it errors preventing you from requesting review.
 - `integrate.verify_isolation` - (**true**/**false** default: **true**) - if **yes** the `integrate` command will run the `isolate` command & it's hooks to verify the patch is isolated prior to integrating it. If the isolation verification fails it errors preventing you from integrating the patch.
 - `integrate.prompt_for_reassurance` - (**true**/**false** default: **true**) - if **yes** the `integrate` command will present the user with the patch details and prompt the user asking them if they are sure they want to integrate the patch. If they say yes, then it moves on the with integration. If not it aborts the integration.
+- `integrate.pull_after_integrate` - (**true**/**false** default: **false**) - if **yes** the `integrate` command will `pull` after a successful integration.
 


### PR DESCRIPTION
Add to the configs page in the docs an explanation about the option to pull after integrating a patch

This is done so users know about this great new feature

I added an entry to the configs page and a short explanation

https://github.com/uptech/git-ps-rs/issues/130
[changelog]
added: entry for pull_after_integrate configuration

ps-id: 4123142d-b592-463b-88c6-0d209420de53