### PR TITLE
Fix hook name in docs

### DIFF
--- a/src/tool/hooks.md
+++ b/src/tool/hooks.md
@@ -43,7 +43,7 @@ filenames.
 	successfully pushing the patch up to the patch stacks upstream remote.
 	This is especially useful when you need to run something after a patch
 	has been successfully integrated but before cleanup.
-- `list_additional_info` - hook executed by `list` command for each patch in
+- `list_additional_information` - hook executed by `list` command for each patch in
   the stack. Adds a column with the output of the hook script. Could be used,
 	for example, to add information from the remote (for example, PR status on github).
 


### PR DESCRIPTION
The hook name is not abbreviated, update the docs accordingly

FI-123

<!-- ps-id: e0e772bb-8bfc-414e-afe3-2bcd2833a911 -->